### PR TITLE
Hide ErrorOverlay iframe

### DIFF
--- a/other/workshop-app-styles.css
+++ b/other/workshop-app-styles.css
@@ -16,3 +16,13 @@ hr {
   margin-top: 30px;
   margin-bottom: 30px;
 }
+
+/* 
+This hides the Create-React-App ErrorOverlay that will overlay the whole application when React fails to compile. The problem here is that it also overlays the workshop instructions with the example
+
+Reference: https://github.com/kentcdodds/react-workshop-app/issues/4
+
+*/
+iframe {
+  display: none;
+}

--- a/other/workshop-app-styles.css
+++ b/other/workshop-app-styles.css
@@ -23,6 +23,6 @@ This hides the Create-React-App ErrorOverlay that will overlay the whole applica
 Reference: https://github.com/kentcdodds/react-workshop-app/issues/4
 
 */
-iframe {
+body:not([class*="isolated"]) iframe {
   display: none;
 }


### PR DESCRIPTION
## Changes made
- iframe display none 
  - Hides the ErrorOverlay iframe that create-react-app enables.

**Why**:
This fixes #4, the iframe hides the workshop instructions which often times can help as you refactor an exercise in the extra credit lessons.

**How**:
In [workshop-app-styles.css](https://github.com/kentcdodds/react-workshop-app/blob/master/other/workshop-app-styles.css): 
```
iframe {
  display: none;
}
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation (inline)
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I had to do two things to get the example running locally:

1. I had to delete the [react-workshop-app/example/react-fundamentals/src/examples/example.tsx](https://github.com/kentcdodds/react-workshop-app/blob/master/example/react-fundamentals/src/examples/example.tsx) file as the set up would 'detect TypeScript', add a tsConfig file and error out because TypeScript wasn't installed.
![Image 2020-07-22 at 4 11 43 PM](https://user-images.githubusercontent.com/6188161/88223940-4966de00-cc36-11ea-859f-b9d4810f5184.png)

2. In [react-fundamentals index page](https://github.com/kentcdodds/react-workshop-app/blob/master/example/react-fundamentals/src/index.js) I had to set `concurrentMode` to `false` because the app would compile with it set to true would produce the error below 
![Image 2020-07-22 at 4 13 00 PM](https://user-images.githubusercontent.com/6188161/88223929-45d35700-cc36-11ea-8bd5-3c19f6ae42cb.png)

```
codegen`module.exports = require('@kentcdodds/react-workshop-app/codegen')({
  options: {concurrentMode: false},
})`
```

![](https://media3.giphy.com/media/m6aZERsqxPiBa/giphy.gif?cid=5a38a5a22q9sm27927v4z0vb32v750mnrspsip22v0bjw8mz&rid=giphy.gif)
