### PR TITLE
fix: update regex to support carriage return

### DIFF
--- a/src/load-files.js
+++ b/src/load-files.js
@@ -28,10 +28,10 @@ function loadFiles({
       if (parentDir === 'final' || parentDir === 'exercise') {
         if (ext === '.js' || ext === '.tsx' || ext === '.ts') {
           const titleMatch =
-            firstLine.match(/\/\/ (?<title>.*)$/) || fallbackMatch
+            firstLine.match(/\/\/ (?<title>.*)[\r]{0,1}$/) || fallbackMatch
           title = titleMatch.groups.title.trim()
           const extraCreditTitleMatch =
-            secondLine.match(/\/\/ 💯 (?<title>.*)$/) || fallbackMatch
+            secondLine.match(/\/\/ 💯 (?<title>.*)[\r]{0,1}$/) || fallbackMatch
           extraCreditTitle = extraCreditTitleMatch.groups.title.trim()
         } else if (ext === '.html') {
           const titleMatch =
@@ -41,7 +41,8 @@ function loadFiles({
             secondLine.match(/<!-- 💯 (?<title>.*) -->/) || fallbackMatch
           extraCreditTitle = extraCreditTitleMatch.groups.title.trim()
         } else if (ext === '.md' || ext === '.mdx') {
-          const titleMatch = firstLine.match(/# (?<title>.*)$/) || fallbackMatch
+          const titleMatch =
+            firstLine.match(/# (?<title>.*)[\r]{0,1}$/) || fallbackMatch
           title = titleMatch.groups.title.trim()
         }
       }


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Regex that checks title and extra title are not working as expected when using CRLF termination of line.
This issue was discovered by @sleepyArpan as discussed on discord 

<!-- Why are these changes necessary? -->

**Why**: Because the string should end with a carriage return

<!-- How were these changes implemented? -->

**How**: I have update the regex to work also with carriage return by adding `[\r]{0,1}` at the end of the regex

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
