### PR TITLE
fix: remove scroll from dev-tools icon

### DIFF
--- a/src/dev-tools/dev-tools.js
+++ b/src/dev-tools/dev-tools.js
@@ -128,6 +128,7 @@ function install() {
               height: '60px',
               width: '68px',
               transition: 'all 0.3s',
+              overflow: 'auto',
             },
             show
               ? {

--- a/src/dev-tools/dev-tools.js
+++ b/src/dev-tools/dev-tools.js
@@ -128,7 +128,6 @@ function install() {
               height: '60px',
               width: '68px',
               transition: 'all 0.3s',
-              overflow: 'scroll',
             },
             show
               ? {


### PR DESCRIPTION
**What**:

removed the scrollbar from the dev-tools icon

**Why**:
the icon looked like this
![image](https://user-images.githubusercontent.com/17033502/92673139-b0da0980-f31a-11ea-8ddd-788e628e2478.png)

<!-- How were these changes implemented? -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
