### PR TITLE
Make test (more) platform independent #18

### DIFF
--- a/src/__tests__/codegen.js
+++ b/src/__tests__/codegen.js
@@ -1,13 +1,19 @@
 import path from 'path'
 import codegen from '../codegen'
 
-const cwd = path.join(__dirname, '../../example/react-fundamentals')
+const cwd = path
+  .join(__dirname, '../../example/react-fundamentals')
+  .split(path.sep)
+  .join('/')
 
 expect.addSnapshotSerializer({
   test(val) {
     return typeof val === 'string'
   },
   print(val) {
+    if (process.platform === 'win32') {
+      val = val.replace(/\\\\/g, '/')
+    }
     return val.split(cwd).join('<PROJECT_ROOT>')
   },
 })


### PR DESCRIPTION

**What**: codegen snapshot test fails on Windows #18 

<!-- Why are these changes necessary? -->

**Why**: The test should run on "all" platforms and report the same results doing so.

<!-- How were these changes implemented? -->

**How**: debugging the test, normalizing path formatting

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Using split/join to replace the path by PROJECT_ROOT is quite nice, have to remember that.
