### PR TITLE
chore: don't break valid linux paths

### DIFF
--- a/other/css-file-to-string.js
+++ b/other/css-file-to-string.js
@@ -1,4 +1,5 @@
 const {execSync} = require('child_process')
+const path = require('path')
 const resolve = require('resolve')
 
 module.exports = filePath =>
@@ -7,5 +8,6 @@ module.exports = filePath =>
       .sync(filePath, {
         basedir: process.cwd(),
       })
-      .replace(/\\/g, '/')}" --use cssnano --no-map`,
+      .split(path.sep)
+      .join('/')}" --use cssnano --no-map`,
   ).toString()


### PR DESCRIPTION

**What**: Make sure **not** to break valid paths on unix-based platforms

**Why**: Using `path.sep` is a more common way to solve cross-platform related problems. This should be used instead of hard coded backslashes.

**How**: Tested using Windows PowerShell and Ubuntu Zsh

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
