### PR TITLE
Fix #39 allow export {App}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cypress/videos
 # when working with contributors
 package-lock.json
 yarn.lock
+.eslintcache

--- a/example/react-fundamentals/src/__tests__/05.js
+++ b/example/react-fundamentals/src/__tests__/05.js
@@ -1,15 +1,15 @@
 import React from 'react'
 import chalk from 'chalk'
 import {render, prettyDOM} from '@testing-library/react'
-import Usage from '../final/05'
-// import Usage from '../exercise/05'
+import {App} from '../final/05'
+// import App from '../exercise/05'
 
 test('renders the correct styles new', () => {
-  const {container, getByText, getAllByText} = render(<Usage />)
+  const {container, getByText, getAllByText} = render(<App />)
   const allBoxes = getAllByText(/box/i)
 
   try {
-    allBoxes.forEach(box => expect(box).toHaveClass('box'))
+    allBoxes.forEach((box) => expect(box).toHaveClass('box'))
   } catch (error) {
     //
     //
@@ -24,7 +24,7 @@ test('renders the correct styles new', () => {
   }
 
   try {
-    allBoxes.forEach(box => expect(box).toHaveStyle('font-style: italic;'))
+    allBoxes.forEach((box) => expect(box).toHaveStyle('font-style: italic;'))
   } catch (error) {
     //
     //

--- a/example/react-fundamentals/src/exercise/05.tsx
+++ b/example/react-fundamentals/src/exercise/05.tsx
@@ -43,4 +43,10 @@ function Usage() {
   )
 }
 
-export default Usage
+// testing a "forgotten" export
+// export default Usage
+
+/*
+eslint
+  @typescript-eslint/no-unused-vars: "off"
+*/

--- a/example/react-fundamentals/src/final/05.tsx
+++ b/example/react-fundamentals/src/final/05.tsx
@@ -28,7 +28,7 @@ const largeBox = (
   </div>
 )
 
-function Usage() {
+function App() {
   return (
     <div>
       {smallBox}
@@ -38,4 +38,4 @@ function Usage() {
   )
 }
 
-export default Usage
+export {App}

--- a/src/__tests__/__snapshots__/codegen.tsx.snap
+++ b/src/__tests__/__snapshots__/codegen.tsx.snap
@@ -136,20 +136,6 @@ const filesInfo = [
     "extraCreditTitle": "Unknown"
   },
   {
-    "id": "src/exercise/05.png",
-    "title": "Unknown",
-    "fullFilePath": "<PROJECT_ROOT>/src/exercise/05.png",
-    "filePath": "src/exercise/05.png",
-    "isolatedPath": "/isolated/exercise/05.png",
-    "ext": ".png",
-    "filename": "05",
-    "type": "exercise",
-    "number": 5,
-    "isExtraCredit": false,
-    "extraCreditNumber": 5,
-    "extraCreditTitle": "Unknown"
-  },
-  {
     "id": "src/exercise/05.tsx",
     "title": "Styling",
     "fullFilePath": "<PROJECT_ROOT>/src/exercise/05.tsx",
@@ -458,20 +444,6 @@ const filesInfo = [
     "extraCreditTitle": "using a custom component with JSX"
   },
   {
-    "id": "src/final/05.png",
-    "title": "Unknown",
-    "fullFilePath": "<PROJECT_ROOT>/src/final/05.png",
-    "filePath": "src/final/05.png",
-    "isolatedPath": "/isolated/final/05.png",
-    "ext": ".png",
-    "filename": "05",
-    "type": "final",
-    "number": 5,
-    "isExtraCredit": false,
-    "extraCreditNumber": 5,
-    "extraCreditTitle": "Unknown"
-  },
-  {
     "id": "src/final/05.tsx",
     "title": "Styling",
     "fullFilePath": "<PROJECT_ROOT>/src/final/05.tsx",
@@ -611,7 +583,6 @@ loadDevTools(() => {
       "src/exercise/04.html": () => import("!raw-loader!./exercise/04.html"),
       "src/exercise/04.md": () => import("!babel-loader!mdx-loader!./exercise/04.md"),
       "src/exercise/05.md": () => import("!babel-loader!mdx-loader!./exercise/05.md"),
-      "src/exercise/05.png": () => import("./exercise/05.png"),
       "src/exercise/05.tsx": () => import("./exercise/05.tsx"),
       "src/exercise/06.js": () => import("./exercise/06.js"),
       "src/exercise/06.md": () => import("!babel-loader!mdx-loader!./exercise/06.md"),
@@ -634,7 +605,6 @@ loadDevTools(() => {
       "src/final/04.html": () => import("!raw-loader!./final/04.html"),
       "src/final/04.extra-1.html": () => import("!raw-loader!./final/04.extra-1.html"),
       "src/final/04.extra-2.html": () => import("!raw-loader!./final/04.extra-2.html"),
-      "src/final/05.png": () => import("./final/05.png"),
       "src/final/05.tsx": () => import("./final/05.tsx"),
       "src/final/05.extra-1.tsx": () => import("./final/05.extra-1.tsx"),
       "src/final/06.js": () => import("./final/06.js"),

--- a/src/__tests__/__snapshots__/codegen.tsx.snap
+++ b/src/__tests__/__snapshots__/codegen.tsx.snap
@@ -10,48 +10,6 @@ if (module.hot) module.hot.accept()
 
 const filesInfo = [
   {
-    "id": "src/examples/example.js",
-    "title": "Unknown",
-    "fullFilePath": "<PROJECT_ROOT>/src/examples/example.js",
-    "filePath": "src/examples/example.js",
-    "isolatedPath": "/isolated/examples/example.js",
-    "ext": ".js",
-    "filename": "example",
-    "type": "examples",
-    "number": 0,
-    "isExtraCredit": false,
-    "extraCreditNumber": 0,
-    "extraCreditTitle": "Unknown"
-  },
-  {
-    "id": "src/examples/non-exported-example.js",
-    "title": "Unknown",
-    "fullFilePath": "<PROJECT_ROOT>/src/examples/non-exported-example.js",
-    "filePath": "src/examples/non-exported-example.js",
-    "isolatedPath": "/isolated/examples/non-exported-example.js",
-    "ext": ".js",
-    "filename": "non-exported-example",
-    "type": "examples",
-    "number": 0,
-    "isExtraCredit": false,
-    "extraCreditNumber": 0,
-    "extraCreditTitle": "Unknown"
-  },
-  {
-    "id": "src/examples/ts-example.tsx",
-    "title": "Unknown",
-    "fullFilePath": "<PROJECT_ROOT>/src/examples/ts-example.tsx",
-    "filePath": "src/examples/ts-example.tsx",
-    "isolatedPath": "/isolated/examples/ts-example.tsx",
-    "ext": ".tsx",
-    "filename": "ts-example",
-    "type": "examples",
-    "number": 0,
-    "isExtraCredit": false,
-    "extraCreditNumber": 0,
-    "extraCreditTitle": "Unknown"
-  },
-  {
     "id": "src/exercise/01.html",
     "title": "Basic JavaScript-rendered Hello World",
     "fullFilePath": "<PROJECT_ROOT>/src/exercise/01.html",
@@ -172,6 +130,20 @@ const filesInfo = [
     "ext": ".md",
     "filename": "05",
     "type": "instruction",
+    "number": 5,
+    "isExtraCredit": false,
+    "extraCreditNumber": 5,
+    "extraCreditTitle": "Unknown"
+  },
+  {
+    "id": "src/exercise/05.png",
+    "title": "Unknown",
+    "fullFilePath": "<PROJECT_ROOT>/src/exercise/05.png",
+    "filePath": "src/exercise/05.png",
+    "isolatedPath": "/isolated/exercise/05.png",
+    "ext": ".png",
+    "filename": "05",
+    "type": "exercise",
     "number": 5,
     "isExtraCredit": false,
     "extraCreditNumber": 5,
@@ -486,6 +458,20 @@ const filesInfo = [
     "extraCreditTitle": "using a custom component with JSX"
   },
   {
+    "id": "src/final/05.png",
+    "title": "Unknown",
+    "fullFilePath": "<PROJECT_ROOT>/src/final/05.png",
+    "filePath": "src/final/05.png",
+    "isolatedPath": "/isolated/final/05.png",
+    "ext": ".png",
+    "filename": "05",
+    "type": "final",
+    "number": 5,
+    "isExtraCredit": false,
+    "extraCreditNumber": 5,
+    "extraCreditTitle": "Unknown"
+  },
+  {
     "id": "src/final/05.tsx",
     "title": "Styling",
     "fullFilePath": "<PROJECT_ROOT>/src/final/05.tsx",
@@ -610,29 +596,12 @@ const filesInfo = [
     "isExtraCredit": true,
     "extraCreditNumber": 1,
     "extraCreditTitle": "Focus Demo"
-  },
-  {
-    "id": "src/index.js",
-    "title": "Unknown",
-    "fullFilePath": "<PROJECT_ROOT>/src/index.js",
-    "filePath": "src/index.js",
-    "isolatedPath": "/isolated/index.js",
-    "ext": ".js",
-    "filename": "index",
-    "type": "src",
-    "number": 0,
-    "isExtraCredit": false,
-    "extraCreditNumber": 0,
-    "extraCreditTitle": "Unknown"
   }
 ]
 
 loadDevTools(() => {
   makeKCDWorkshopApp({
     imports: {
-      "src/examples/example.js": () => import("./examples/example.js"),
-      "src/examples/non-exported-example.js": () => import("./examples/non-exported-example.js"),
-      "src/examples/ts-example.tsx": () => import("./examples/ts-example.tsx"),
       "src/exercise/01.html": () => import("!raw-loader!./exercise/01.html"),
       "src/exercise/01.md": () => import("!babel-loader!mdx-loader!./exercise/01.md"),
       "src/exercise/02.html": () => import("!raw-loader!./exercise/02.html"),
@@ -642,6 +611,7 @@ loadDevTools(() => {
       "src/exercise/04.html": () => import("!raw-loader!./exercise/04.html"),
       "src/exercise/04.md": () => import("!babel-loader!mdx-loader!./exercise/04.md"),
       "src/exercise/05.md": () => import("!babel-loader!mdx-loader!./exercise/05.md"),
+      "src/exercise/05.png": () => import("./exercise/05.png"),
       "src/exercise/05.tsx": () => import("./exercise/05.tsx"),
       "src/exercise/06.js": () => import("./exercise/06.js"),
       "src/exercise/06.md": () => import("!babel-loader!mdx-loader!./exercise/06.md"),
@@ -664,6 +634,7 @@ loadDevTools(() => {
       "src/final/04.html": () => import("!raw-loader!./final/04.html"),
       "src/final/04.extra-1.html": () => import("!raw-loader!./final/04.extra-1.html"),
       "src/final/04.extra-2.html": () => import("!raw-loader!./final/04.extra-2.html"),
+      "src/final/05.png": () => import("./final/05.png"),
       "src/final/05.tsx": () => import("./final/05.tsx"),
       "src/final/05.extra-1.tsx": () => import("./final/05.extra-1.tsx"),
       "src/final/06.js": () => import("./final/06.js"),
@@ -672,8 +643,7 @@ loadDevTools(() => {
       "src/final/07.js": () => import("./final/07.js"),
       "src/final/08.js": () => import("./final/08.js"),
       "src/final/09.js": () => import("./final/09.js"),
-      "src/final/09.extra-1.js": () => import("./final/09.extra-1.js"),
-      "src/index.js": () => import("./index.js")
+      "src/final/09.extra-1.js": () => import("./final/09.extra-1.js")
     },
     filesInfo,
     projectTitle: pkg.title,

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -26,22 +26,35 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-test('regular app', () => {
-  const {filesInfo, gitHubRepoUrl} = getAppInfo({
+function setup() {
+  const {filesInfo: filesInfoRaw, gitHubRepoUrl} = getAppInfo({
     cwd: path.join(process.cwd(), 'example/react-fundamentals'),
   })
 
+  const imports = {
+    'src/exercise/05.tsx': () =>
+      import('../../example/react-fundamentals/src/exercise/05.tsx'),
+    'src/exercise/05.md': () =>
+      import('../../example/react-fundamentals/src/exercise/05.md'),
+    'src/final/05.tsx': () =>
+      import('../../example/react-fundamentals/src/final/05.tsx'),
+    'src/final/05.extra-1.tsx': () =>
+      import('../../example/react-fundamentals/src/final/05.extra-1.tsx'),
+  }
+  const filesInfo = filesInfoRaw.filter(({id}) => imports[id])
+
+  expect(filesInfo.map(({id}) => id).sort()).toEqual(
+    Object.keys(imports).sort(),
+  )
+
+  return {imports, filesInfo, gitHubRepoUrl}
+}
+
+test('regular app', () => {
+  const {imports, filesInfo, gitHubRepoUrl} = setup()
+
   makeKCDWorkshopApp({
-    imports: {
-      'src/exercise/05.js': () =>
-        import('../../example/react-fundamentals/src/exercise/05.js'),
-      'src/exercise/05.md': () =>
-        import('../../example/react-fundamentals/src/exercise/05.md'),
-      'src/final/05.js': () =>
-        import('../../example/react-fundamentals/src/final/05.js'),
-      'src/final/05.extra-1.js': () =>
-        import('../../example/react-fundamentals/src/final/05.extra-1.js'),
-    },
+    imports,
     filesInfo,
     gitHubRepoUrl,
     projectTitle: 'test project',
@@ -55,25 +68,13 @@ test('regular app', () => {
   )
 })
 
-// TODO: fix this test
-test.skip('isolated page', async () => {
-  const {filesInfo, gitHubRepoUrl} = getAppInfo({
-    cwd: path.join(process.cwd(), 'example/react-fundamentals'),
-  })
+test('isolated page', async () => {
+  const {imports, filesInfo, gitHubRepoUrl} = setup()
 
-  window.history.pushState({}, 'Test page', '/isolated/final/05.js')
+  window.history.pushState({}, 'Test page', '/isolated/final/05.tsx')
 
   makeKCDWorkshopApp({
-    imports: {
-      'src/exercise/05.js': () =>
-        import('../../example/react-fundamentals/src/exercise/05.js'),
-      'src/exercise/05.md': () =>
-        import('../../example/react-fundamentals/src/exercise/05.md'),
-      'src/final/05.js': () =>
-        import('../../example/react-fundamentals/src/final/05.js'),
-      'src/final/05.extra-1.js': () =>
-        import('../../example/react-fundamentals/src/final/05.extra-1.js'),
-    },
+    imports,
     filesInfo,
     gitHubRepoUrl,
     projectTitle: 'test project',
@@ -82,8 +83,3 @@ test.skip('isolated page', async () => {
 
   await screen.findByText('large orange box')
 })
-
-/*
-eslint
-  import/no-unresolved: "off",
-*/

--- a/src/codegen.tsx
+++ b/src/codegen.tsx
@@ -3,17 +3,12 @@ import {getAppInfo} from './get-app-info'
 
 function getCode({
   cwd = process.cwd(),
-  ignore,
   options,
 }: {
   cwd?: string
-  ignore?: Array<string>
   options?: Record<string, unknown>
 } = {}) {
-  const {gitHubRepoUrl, filesInfo, hasBackend, imports} = getAppInfo({
-    cwd,
-    ignore,
-  })
+  const {gitHubRepoUrl, filesInfo, hasBackend, imports} = getAppInfo({cwd})
   return `
 import {makeKCDWorkshopApp} from '@kentcdodds/react-workshop-app'
 import {loadDevTools} from '@kentcdodds/react-workshop-app/dev-tools'

--- a/src/get-app-info.tsx
+++ b/src/get-app-info.tsx
@@ -4,16 +4,13 @@ import path from 'path'
 import {loadFiles} from './load-files'
 import type {FileInfo} from './types'
 
-function getAppInfo({
-  cwd = process.cwd(),
-  ignore,
-}: {cwd?: string; ignore?: Array<string>} = {}): {
+function getAppInfo({cwd = process.cwd()}: {cwd?: string} = {}): {
   gitHubRepoUrl: string
   filesInfo: Array<FileInfo>
   imports: Array<string>
   hasBackend: boolean
 } {
-  const filesInfo = loadFiles({cwd, ignore})
+  const filesInfo = loadFiles({cwd})
   let gitHubRepoUrl
   const pkgPath = path.join(process.cwd(), 'package.json')
   try {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -286,25 +286,24 @@ function moduleWithDefaultExport(imports: Imports, filePath: string) {
   const importFn = imports[filePath]
   if (!importFn) throw new Error(`'${filePath}' does not exist in imports.`)
 
-  if (filePath.match(/\.mdx?$/)) return importFn as DefaultDynamicImportFn
+  if (filePath.match(/\.(mdx?|html)$/))
+    return importFn as DefaultDynamicImportFn
 
   const promiseOfModule = importFn()
   const promiseOfDefault: ReturnType<DefaultDynamicImportFn> = promiseOfModule
     .then(module => {
       const Component = module.App ?? module.default
-      if (!Component) {
-        throw Error(
-          'Please add a `export {App}` or `export default ...` to your exercise file to render it.',
+      if (typeof Component !== 'function') {
+        throw new Error(
+          'Please add `export {App}` or `export default Component` to your exercise file to render it.',
         )
       }
       return {default: Component}
     })
-    .catch(error => {
+    .catch((error: Error) => {
       console.error(filePath, error)
       return {
-        default: () => {
-          throw error
-        },
+        default: () => <div>{error.message}</div>,
       }
     })
 
@@ -317,5 +316,6 @@ eslint
   babel/no-unused-expressions: "off",
   @typescript-eslint/no-explicit-any: "off",
   @typescript-eslint/prefer-regexp-exec: "off",
+  react/jsx-no-useless-fragment: "off",
   no-void: "off"
 */

--- a/src/load-files.tsx
+++ b/src/load-files.tsx
@@ -5,7 +5,7 @@ import type {FileInfo} from './types'
 
 function loadFiles({cwd = process.cwd(), ...rest} = {}): Array<FileInfo> {
   const fileInfo = glob
-    .sync('src/{exercise,final}/*.+(js|html|jsx|ts|tsx|md|mdx)', {cwd, ...rest})
+    .sync('src/{exercise,final,examples}/*.+(js|html|jsx|ts|tsx|md|mdx)', {cwd, ...rest})
     // eslint-disable-next-line complexity
     .map(filePath => {
       const fullFilePath = path.join(cwd, filePath)

--- a/src/load-files.tsx
+++ b/src/load-files.tsx
@@ -3,20 +3,9 @@ import fs from 'fs'
 import glob from 'glob'
 import type {FileInfo} from './types'
 
-function loadFiles({
-  cwd = process.cwd(),
-  ignore = [
-    '**/__tests__/**',
-    '**/test/**',
-    '**/backend.+(js|ts|tsx)',
-    '**/setupTests.+(js|ts|tsx)',
-    '**/setupProxy.+(js|ts|tsx)',
-    '**/*.d.ts',
-  ],
-  ...rest
-} = {}): Array<FileInfo> {
+function loadFiles({cwd = process.cwd(), ...rest} = {}): Array<FileInfo> {
   const fileInfo = glob
-    .sync('src/**/*.+(js|html|jsx|ts|tsx|md|mdx)', {cwd, ignore, ...rest})
+    .sync('src/{exercise,final}/*.*', {cwd, ...rest})
     // eslint-disable-next-line complexity
     .map(filePath => {
       const fullFilePath = path.join(cwd, filePath)

--- a/src/load-files.tsx
+++ b/src/load-files.tsx
@@ -5,7 +5,7 @@ import type {FileInfo} from './types'
 
 function loadFiles({cwd = process.cwd(), ...rest} = {}): Array<FileInfo> {
   const fileInfo = glob
-    .sync('src/{exercise,final}/*.*', {cwd, ...rest})
+    .sync('src/{exercise,final}/*.+(js|html|jsx|ts|tsx|md|mdx)', {cwd, ...rest})
     // eslint-disable-next-line complexity
     .map(filePath => {
       const fullFilePath = path.join(cwd, filePath)

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,11 +15,23 @@ type FileInfo = {
   extraCreditTitle?: string
 }
 
-type LazyComponents = Record<string, React.LazyExoticComponent<any> | undefined>
+type NoPropsComponent = React.ComponentType<{}>
 
-type DynamicImportFn = () => Promise<{default: React.ComponentType<unknown>}>
+type LazyComponents = Record<
+  string,
+  React.LazyExoticComponent<NoPropsComponent> | undefined
+>
 
-type Imports = Record<string, DynamicImportFn>
+type DynamicImportFn = () => Promise<{
+  App?: NoPropsComponent
+  default?: NoPropsComponent
+}>
+
+type DefaultDynamicImportFn = () => Promise<{
+  default: NoPropsComponent
+}>
+
+type Imports = Record<string, DynamicImportFn | undefined>
 
 type Backend = {
   handlers: Array<RequestHandler>
@@ -30,7 +42,15 @@ type Backend = {
   [key: string]: unknown
 }
 
-export type {FileInfo, LazyComponents, Imports, Backend, DynamicImportFn}
+export type {
+  FileInfo,
+  LazyComponents,
+  Imports,
+  Backend,
+  NoPropsComponent,
+  DynamicImportFn,
+  DefaultDynamicImportFn,
+}
 
 /*
 eslint


### PR DESCRIPTION
**What**:
* convert Promises of {App} modules into {default} for React.lazy
* import only exercise and final folders, do not React.lazy random files
  (the current `ignore` blacklist was not enough)

**Why**:

Fixes #39

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged

**Notes**:

While typecheck and tests are all fine (and `test('isolated page', ...` failed when I deleted `export {App}` in `final/05.tsx`), I was not able to test manually with `npm run dev` because of problems described in #39.

If you like the idea but decide to go in a different direction, feel free to close this PR and pick useful parts of code during some future live stream.