### PR TITLE
Fix Alfred the Alert Helper

### DIFF
--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -19,13 +19,13 @@ function alfredTip(
 
   const tipString = typeof tip === 'function' ? tip(caughtError) : tip
   const error = new Error(chalk.red(`🚨 ${tipString}`))
-  // get rid of the stack to avoid the noisy codeframe
-  error.stack = ''
   if (displayEl) {
     const el =
       typeof displayEl === 'function' ? displayEl(caughtError) : document.body
     error.message += `\n\n${chalk.reset(prettyDOM(el))}`
   }
+  // get rid of the stack to avoid the noisy codeframe
+  error.stack = error.message
   throw error
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes [#298 on react-fundamentals](https://github.com/kentcdodds/react-fundamentals/issues/298)

<!-- Why are these changes necessary? -->

**Why**:

The helper for Alfred the alert is used to give hints on why tests failed. It does so by raising a custom error. In order to not bloat the terminal window with stack traces, the code clears the error's `stack` property.

It turns out that the stack is what's show in the terminal when tests fail. So when tests fail and the stack is set to a blank string, Alfred the alert's helpful tips don't show up in your terminal. :(

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

When investigating, it looks like the stack included both the error's message _and_ a stack trace.
So instead of clearing the stack, I replaced the stack's content with just the error's message. Now, only the error message shows up when a test fails.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
    - Existing tests still pass. If necessary, I can add a test that asserts the stack equals the message passed in the constructor?
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
